### PR TITLE
Fixed problem #1, #2,#3, #4 in PT289

### DIFF
--- a/src/components/book/BookCard.js
+++ b/src/components/book/BookCard.js
@@ -273,7 +273,6 @@ class BookCard extends Component {
   handleAgree = (e) => {
     // this.props.getBook(this.props.book.bookId);
     this.props.history.push(`/book/${this.props.book.bookId}/chapters`);
-    console.log(this.props);
   };
   bookCardMediaMouseEnter = () => {
     this.setState({ bookCardMediaMouseInside: true });
@@ -307,7 +306,6 @@ class BookCard extends Component {
         credentials: { handle },
       },
     } = this.props;
-
     const deleteButton =
       authenticated && userHandle === handle ? (
         <DeleteBook bookId={bookId} title={title} />

--- a/src/components/chapter/ChapterEditor.js
+++ b/src/components/chapter/ChapterEditor.js
@@ -15,6 +15,7 @@
  */
 // React
 import React, { Component, Fragment } from "react";
+import { withRouter } from "react-router-dom";
 // MUI Core
 import Box from "@material-ui/core/Box";
 import Button from "@material-ui/core/Button";
@@ -24,7 +25,7 @@ import FormControlLabel from "@material-ui/core/FormControlLabel";
 import Switch from "@material-ui/core/Switch";
 import IconButton from "@material-ui/core/IconButton";
 import withStyles from "@material-ui/core/styles/withStyles";
-import CircularProgress from "@material-ui/core/CircularProgress";
+// import CircularProgress from "@material-ui/core/CircularProgress";
 // MUI Icon
 import MoreHorizIcon from "@material-ui/icons/MoreHoriz";
 // Redux
@@ -50,31 +51,62 @@ class ChapterEditor extends Component {
     super(props);
     this.state = {
       editorHtml: this.props.chapter.body,
+      previousEditorHtml: null,
+      previousChapter: null,
       bookId: this.props.bookId,
+      saveButtonDisabled: false,
+      chapterList: this.props.chapterList,
     };
     this.handleChange = this.handleChange.bind(this);
+  }
+  componentDidUpdate(prevProps) {
+    if (this.props.triggerChildFunc !== prevProps.triggerChildFunc) {
+      this.setState({ previousChapter: this.props.chapter });
+      this.onParentTrigger();
+    }
+  }
+  onParentTrigger() {
+    if (
+      this.props.triggerChildFunc &&
+      {}.toString.call(this.props.triggerChildFunc) === "[object Function]"
+    ) {
+      this.props.triggerChildFunc();
+    }
+    let previousChapter = this.state.previousChapter;
+    let previousEditorHtml = this.state.previousEditorHtml;
+    if (previousChapter !== null) {
+      previousChapter.body = previousEditorHtml;
+      this.props.submitEditChapter(previousChapter, this.props.bookId);
+    }
   }
   componentWillReceiveProps(nextProps) {
     this.setState({ editorHtml: nextProps.chapter.body });
   }
-  componentDidUpdate() {
-    // console.log(this.state.bookId);
-    // console.log(this.props.chapterId)
-    // console.log(this.props.chapter)
-  }
+  // checkEditorHtmlLengthChanged() {
+  //   if (this.state.editorHtml.length !== this.props.chapter.body.length)
+  //   {
+  //     this.setState({ saveButtonDisabled: false });
+  //   }else{
+  //     this.setState({ saveButtonDisabled: true });
+  //   }
+  // }
   handleChange(html) {
     this.setState({ editorHtml: html });
+    this.setState({ previousEditorHtml: html });
+    // this.checkEditorHtmlLengthChanged();
   }
+
   handleSave(bookId) {
-    // this.props.history.push(`/book/chapters`);
-    const editChapter = this.props.chapter;
-    editChapter.body = this.state.editorHtml;
-    this.props.submitEditChapter(editChapter, bookId);
+    // const editChapter = this.props.chapter;
+    // editChapter.body = this.state.editorHtml;
+    // this.props.submitEditChapter(editChapter, bookId);
+    let userHandle = bookId.split("_");
+    this.props.history.push(`/contentcreation/${userHandle[0]}`);
   }
   render() {
     const {
       classes,
-      UI: { loading },
+      // UI: { loading },
     } = this.props;
     // module and format for Quill.js Embeded Text Editor
     const chapterEditor = {
@@ -122,53 +154,56 @@ class ChapterEditor extends Component {
     };
     return (
       <Fragment>
-        <Box display="flex" justifyContent="space-between">
-          <Box display="flex" justifyContent="space-evenly">
-            {/* Auto Save button */}
-            <Box marginRight="2em">
-              <FormControl component="fieldset">
-                <FormGroup aria-label="position" row>
-                  <FormControlLabel
-                    value="start"
-                    control={<Switch color="primary" />}
-                    label="AutoSave"
-                    labelPlacement="start"
-                    disabled
-                  />
-                </FormGroup>
-              </FormControl>
+        {this.props.chapter.chapterId === null ? null : (
+          <Box display="flex" justifyContent="space-between">
+            <Box display="flex" justifyContent="space-evenly">
+              {/* Auto Save button */}
+              <Box marginRight="2em">
+                <FormControl component="fieldset">
+                  <FormGroup aria-label="position" row>
+                    <FormControlLabel
+                      value="start"
+                      control={<Switch color="primary" />}
+                      label="AutoSave"
+                      labelPlacement="start"
+                      disabled
+                    />
+                  </FormGroup>
+                </FormControl>
+              </Box>
+              {/* Save and Save as button  */}
+              <Box marginRight="2em" className={classes.button}>
+                <Button
+                  variant="outlined"
+                  onClick={() => this.handleSave(this.state.bookId)}
+                  disabled={this.state.saveButtonDisabled}
+                >
+                  Save
+                  {/* {loading && <CircularProgress size={30} />} */}
+                </Button>
+              </Box>
+              <Box marginRight="2em" className={classes.button}>
+                <Button variant="outlined" disabled>
+                  Save as
+                </Button>
+              </Box>
             </Box>
-            {/* Save and Save as button  */}
-            <Box marginRight="2em" className={classes.button}>
-              <Button
-                variant="outlined"
-                disabled={loading}
-                onClick={() => this.handleSave(this.state.bookId)}
-              >
-                Save
-                {loading && <CircularProgress size={30} />}
-              </Button>
-            </Box>
-            <Box marginRight="2em" className={classes.button}>
-              <Button variant="outlined" disabled>
-                Save as
-              </Button>
+            {/* Export and additional button */}
+            <Box display="flex" justifyContent="space-evenly">
+              <Box className={classes.button}>
+                <Button variant="outlined" disabled className={classes.button}>
+                  Export
+                </Button>
+              </Box>
+              <IconButton aria-label="additional menu" disabled>
+                <MoreHorizIcon />
+              </IconButton>
             </Box>
           </Box>
-          {/* Export and additional button */}
-          <Box display="flex" justifyContent="space-evenly">
-            <Box className={classes.button}>
-              <Button variant="outlined" disabled className={classes.button}>
-                Export
-              </Button>
-            </Box>
-            <IconButton aria-label="additional menu" disabled>
-              <MoreHorizIcon />
-            </IconButton>
-          </Box>
-        </Box>
+        )}
+
         {/* Quill.js Embeded Text Editor class Component */}
-        {this.props.chapter === null ? (
+        {this.props.chapterId === null ? (
           <Typography variant="h5">No chapter selected</Typography>
         ) : (
           <ReactQuill
@@ -183,9 +218,11 @@ class ChapterEditor extends Component {
     );
   }
 }
+const mapActionsToProps = { submitEditChapter };
 const mapStateToProps = (state) => ({
   UI: state.UI,
 });
-export default connect(mapStateToProps, { submitEditChapter })(
-  withStyles(styles)(ChapterEditor)
-);
+export default connect(
+  mapStateToProps,
+  mapActionsToProps
+)(withStyles(styles)(withRouter(ChapterEditor)));

--- a/src/components/chapter/CreateChapter.js
+++ b/src/components/chapter/CreateChapter.js
@@ -170,10 +170,10 @@ class CreateChapter extends Component {
     );
     return (
       <Fragment>
+        {createChapterDialog}
         <Button className={classes.button} onClick={this.handleOpen} fullWidth>
           +
         </Button>
-        {createChapterDialog}
       </Fragment>
     );
   }

--- a/src/pages/chapter/chapter.js
+++ b/src/pages/chapter/chapter.js
@@ -12,6 +12,7 @@
  * - 09 July 2020, Martin Hwang <m.hwang@proudtale.com> : Modified and fixed
  */
 import React, { Component, Fragment } from "react";
+import { withRouter } from "react-router-dom";
 import PropTypes from "prop-types";
 // CLSX
 import clsx from "clsx";
@@ -118,8 +119,9 @@ class chapter extends Component {
       chapterInChapterEditor: {
         chapterId: null,
         title: null,
-        body: "<h3>Please select chapter</h3>",
+        body: "<h1>Please select chapter</h1>",
         createdAt: null,
+        triggerFunc: null,
       },
       selectedChapterId: null,
     };
@@ -131,7 +133,7 @@ class chapter extends Component {
     );
   }
   componentDidMount() {
-    this.handleAssignChapterToPropsInChapterEditor();
+    // this.handleAssignChapterToPropsInChapterEditor();
   }
   handleMenuDrawer = () => {
     this.setState({ open: !this.state.open });
@@ -146,6 +148,7 @@ class chapter extends Component {
       }
       i++;
     }
+    this.setState({ triggerFunc: () => {} });
   }
   render() {
     const { chapters } = this.props.chapter;
@@ -170,6 +173,7 @@ class chapter extends Component {
             chapter={this.state.chapterInChapterEditor}
             chapterId={this.state.selectedChapterId}
             className={classes.chapterEditor}
+            triggerChildFunc={this.state.triggerFunc}
           />
         </Grid>
       </Fragment>
@@ -270,4 +274,4 @@ export default connect(mapStateToProps, {
   getChapters,
   editChapter,
   clearErrors,
-})(withStyles(sytles)(chapter));
+})(withStyles(sytles)(withRouter(chapter)));

--- a/src/redux/actions/chapterActions.js
+++ b/src/redux/actions/chapterActions.js
@@ -21,6 +21,7 @@ import {
   SET_BOOK_CHAPTER,
   SUBMIT_EDIT_CHAPTER,
   EDIT_CHAPTER,
+  // STOP_LOADING_UI,
   // ADD_CHAPTER,
   // DELETE_CHAPTER,
   // EDIT_CHAPTER_TITLE,
@@ -77,6 +78,7 @@ export const postChapter = (newChapter, bookId) => (dispatch) => {
         type: POST_CHAPTER,
         payload: res.data,
       });
+      dispatch(getChapters(bookId)); // for element in chapter array goes back to end of array.
       dispatch(clearErrors());
     })
     .catch((err) => {


### PR DESCRIPTION
https://proudtale.atlassian.net/browse/PT-289?atlOrigin=eyJpIjoiNTU3MTUxZjNmYzUyNDU4YWE4MGJlMzZkMDZmMjk4OGEiLCJwIjoiaiJ9

1. When I make a new chapter, it puts that chapter at the top, is there a way we can get that newly created chapter moved below the existing chapters?

2. Once I create a new chapter, let it temporarily save the text in the text editor and show the text made for the new chapter made. When I click back to the last chapter I typed in the text editor, it shows what I last made in there.

3. When I currently, click save, the text in the text editor saves for that chapter. Is there a way to have it automatically save as I click off into a new chapter? So, can you let it save temporarily when I click a different chapter without clicking “Save”? Can we please remove the Save button functionality

3.Once I click out and come back to edit from the Content Creation page, I don’t expect the chapters to actually save until we click “Save” or “Save as” as outlined in
PT-112: As a content creator, I can click "Save" and the book will save to the Content Creation Page in the "In Progress" row.To Do